### PR TITLE
Bypass Vercel Image Optimization for TMDB images

### DIFF
--- a/client/next.config.ts
+++ b/client/next.config.ts
@@ -5,6 +5,13 @@ const monorepoRoot = path.join(__dirname, "..");
 
 const nextConfig: NextConfig = {
   images: {
+    // Bypass Vercel Image Optimization for TMDB images: the custom loader
+    // returns TMDB's own pre-sized CDN URLs, so no transformations are billed.
+    // See src/lib/tmdb-image-loader.ts. `remotePatterns` is retained so the
+    // config still documents the allowed host and works if the loader is
+    // reverted (it is ignored while a custom loader is active).
+    loader: "custom",
+    loaderFile: "./src/lib/tmdb-image-loader.ts",
     remotePatterns: [
       {
         hostname: "image.tmdb.org",

--- a/client/src/lib/tmdb-image-loader.ts
+++ b/client/src/lib/tmdb-image-loader.ts
@@ -1,0 +1,42 @@
+"use client";
+
+/**
+ * Custom `next/image` loader for TMDB images.
+ *
+ * TMDB already serves pre-generated, CDN-cached renditions at fixed size
+ * segments (e.g. `https://image.tmdb.org/t/p/w500/xyz.jpg`). Returning those
+ * URLs directly means Vercel's Image Optimization is never invoked, so we are
+ * not billed for transformations — TMDB's CDN does the resizing for free.
+ *
+ * Each call site already picks an appropriate size (`w200`/`w342`/`w500`/
+ * `original`). We honor that size and only promote to `original` when
+ * `next/image` requests a wider render (e.g. for high-DPR screens). `original`
+ * is valid for every TMDB image type, so this never produces a broken URL —
+ * unlike mapping to an arbitrary `w###`, which 404s for types that don't list
+ * that size. Non-TMDB or already-`original` srcs are returned untouched.
+ */
+
+interface TmdbImageLoaderParams {
+  quality?: number;
+  src: string;
+  width: number;
+}
+
+const TMDB_SIZED_PATH = /\/t\/p\/w(\d+)\//;
+
+export default function tmdbImageLoader({
+  src,
+  width,
+}: TmdbImageLoaderParams): string {
+  const match = src.match(TMDB_SIZED_PATH);
+
+  // Already `original`, or not a TMDB URL (e.g. a local /public asset).
+  if (!match) return src;
+
+  const currentWidth = Number(match[1]);
+  if (width > currentWidth) {
+    return src.replace(TMDB_SIZED_PATH, "/t/p/original/");
+  }
+
+  return src;
+}


### PR DESCRIPTION
Add a custom next/image loader that returns TMDB's own pre-sized CDN URLs, so no Vercel image transformations are billed. Honors the size chosen at each call site and only promotes to `original` for wider renders (valid for all TMDB image types).

Fixes runaway Image Optimization usage on the production (main) app.