### PR TITLE
Keep the TMDB read access token on the server

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -42,3 +42,5 @@ next-env.d.ts
 
 # backup software
 .sync.ffs_db
+# Local Netlify folder
+.netlify

--- a/client/.env.example
+++ b/client/.env.example
@@ -1,4 +1,5 @@
-NEXT_PUBLIC_API_KEY=""
+# Server-only: the raw TMDB read access token, without a "Bearer " prefix.
+TMDB_API_KEY=""
 NEXT_PUBLIC_API_URL=""
 NEXT_PUBLIC_API_IMAGE_PATH=""
 NEXT_PUBLIC_SITE_URL="https://yourdomain.com"

--- a/client/AGENTS.md
+++ b/client/AGENTS.md
@@ -143,7 +143,7 @@ When creating client components that use browser-specific features:
 
 - **API:** The Movie Database (TMDB)
 - **Environment Variables:**
-  - `NEXT_PUBLIC_API_KEY` - TMDB API authorization
+  - `TMDB_API_KEY` - TMDB read access token (server-only, no `NEXT_PUBLIC_` prefix, no `Bearer ` prefix in the value)
   - `NEXT_PUBLIC_API_URL` - TMDB API base URL
 
 ### Data Layer Architecture
@@ -154,12 +154,21 @@ When creating client components that use browser-specific features:
 
 ```
 src/
+├── app/api/                # Route handlers exposing loaders to the browser
 ├── data/
-│   └── loaders.ts          # All API data fetching functions
+│   ├── loaders.ts          # All API data fetching functions (server-only)
+│   └── client-loaders.ts   # Browser-side callers of the /api routes
 ├── utils/
-│   └── fetch-apis.ts       # Generic fetch utilities
+│   └── fetch-apis.ts       # Generic fetch utilities (server-only)
 └── components/             # UI components (NO direct API calls)
 ```
+
+**The TMDB token never reaches the browser.** `loaders.ts` and `fetch-apis.ts`
+both `import "server-only"`, so importing them from a `"use client"` component
+is a build error. Client components import the matching function from
+`client-loaders.ts` instead, which calls a route handler under `src/app/api`.
+When adding a loader that a client component needs, add the route handler and
+the `client-loaders.ts` wrapper alongside it.
 
 #### **Pattern: Centralized Loaders**
 

--- a/client/README.md
+++ b/client/README.md
@@ -31,13 +31,15 @@ Data is sourced entirely from [The Movie Database (TMDB) API v3](https://develop
 Create a `.env.local` file in this directory with your TMDB credentials:
 
 ```bash
-NEXT_PUBLIC_API_KEY=Bearer <your_tmdb_read_access_token>
+TMDB_API_KEY=your_tmdb_read_access_token
 NEXT_PUBLIC_API_URL=https://api.themoviedb.org/3
 NEXT_PUBLIC_API_IMAGE_PATH=https://image.tmdb.org/t/p/
 NEXT_PUBLIC_SITE_URL=http://localhost:3000
 ```
 
 A free TMDB API read access token can be obtained at [themoviedb.org/settings/api](https://www.themoviedb.org/settings/api).
+
+`TMDB_API_KEY` holds the token on its own — the `Bearer ` prefix is added in code, so don't include it in the value. The variable is intentionally not prefixed with `NEXT_PUBLIC_`: it is read only on the server, and browser requests reach TMDB through the route handlers in `src/app/api`.
 
 ### Run the development server
 

--- a/client/netlify.toml
+++ b/client/netlify.toml
@@ -1,0 +1,3 @@
+[build.environment]
+  # Documentation files contain placeholder env var examples, not real secrets.
+  SECRETS_SCAN_OMIT_PATHS = "README.md,AGENTS.md,.env.example"

--- a/client/package-lock.json
+++ b/client/package-lock.json
@@ -25,6 +25,7 @@
         "next-themes": "^0.4.6",
         "react": "^19.0.0",
         "react-dom": "^19.0.0",
+        "server-only": "^0.0.1",
         "tailwind-merge": "^3.3.0"
       },
       "devDependencies": {
@@ -4450,6 +4451,7 @@
       "version": "2.3.2",
       "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
       "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+      "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
       "optional": true,
@@ -6677,6 +6679,12 @@
       "engines": {
         "node": ">=10"
       }
+    },
+    "node_modules/server-only": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/server-only/-/server-only-0.0.1.tgz",
+      "integrity": "sha512-qepMx2JxAa5jjfzxG79yPPq+8BuFToHd1hm7kI+Z4zAq1ftQiP7HcxMhDDItrbtwVeLg/cY2JnKnrcFkmiswNA==",
+      "license": "MIT"
     },
     "node_modules/set-function-length": {
       "version": "1.2.2",

--- a/client/package.json
+++ b/client/package.json
@@ -26,6 +26,7 @@
     "next-themes": "^0.4.6",
     "react": "^19.0.0",
     "react-dom": "^19.0.0",
+    "server-only": "^0.0.1",
     "tailwind-merge": "^3.3.0"
   },
   "devDependencies": {

--- a/client/src/app/api/movies/now-playing/route.ts
+++ b/client/src/app/api/movies/now-playing/route.ts
@@ -1,0 +1,8 @@
+import { getNowPlayingMovies } from "@/data/loaders";
+import { movieListResponse, regionFromRequest } from "@/lib/api";
+
+export async function GET(request: Request) {
+  const movies = await getNowPlayingMovies(regionFromRequest(request));
+
+  return movieListResponse(movies, "Failed to fetch now playing movies");
+}

--- a/client/src/app/api/movies/trending/route.ts
+++ b/client/src/app/api/movies/trending/route.ts
@@ -1,0 +1,8 @@
+import { getTrendingMovies } from "@/data/loaders";
+import { movieListResponse } from "@/lib/api";
+
+export async function GET() {
+  const movies = await getTrendingMovies();
+
+  return movieListResponse(movies, "Failed to fetch trending movies");
+}

--- a/client/src/app/api/movies/upcoming/route.ts
+++ b/client/src/app/api/movies/upcoming/route.ts
@@ -1,0 +1,8 @@
+import { getUpcomingMovies } from "@/data/loaders";
+import { movieListResponse, regionFromRequest } from "@/lib/api";
+
+export async function GET(request: Request) {
+  const movies = await getUpcomingMovies(regionFromRequest(request));
+
+  return movieListResponse(movies, "Failed to fetch upcoming movies");
+}

--- a/client/src/app/api/search/route.ts
+++ b/client/src/app/api/search/route.ts
@@ -1,0 +1,14 @@
+import { getSearchResults } from "@/data/loaders";
+import { movieListResponse } from "@/lib/api";
+
+export async function GET(request: Request) {
+  const term = new URL(request.url).searchParams.get("term");
+
+  if (!term) {
+    return movieListResponse([], "Failed to fetch search results");
+  }
+
+  const movies = await getSearchResults(term);
+
+  return movieListResponse(movies, "Failed to fetch search results");
+}

--- a/client/src/app/search/client-search.tsx
+++ b/client/src/app/search/client-search.tsx
@@ -7,7 +7,7 @@ import { useSearchParams } from "next/navigation";
 import { MovieList } from "@/components/movies/movie-list";
 import SkeletonCardList from "@/components/skeletons/skeleton-card-list";
 
-import { getSearchResults } from "@/data/loaders";
+import { getSearchResults } from "@/data/client-loaders";
 import type { Movie } from "@/types";
 
 export default function ClientSearch() {

--- a/client/src/components/movies/movie-fetcher.tsx
+++ b/client/src/components/movies/movie-fetcher.tsx
@@ -8,7 +8,7 @@ import {
   getNowPlayingMovies,
   getTrendingMovies,
   getUpcomingMovies,
-} from "@/data/loaders";
+} from "@/data/client-loaders";
 import { useRegion } from "@/lib/region-context";
 import type { Movie } from "@/types";
 

--- a/client/src/data/client-loaders.ts
+++ b/client/src/data/client-loaders.ts
@@ -1,0 +1,47 @@
+import type { Movie } from "@/types";
+
+/**
+ * Browser-side counterparts to src/data/loaders.ts.
+ *
+ * Client components can't call the loaders directly — those hold the TMDB
+ * token and are marked `server-only`. These hit our own route handlers under
+ * /api instead, and return the same `Movie[] | null` shape.
+ */
+async function fetchMovies(path: string): Promise<Movie[] | null> {
+  try {
+    const response = await fetch(path);
+
+    if (!response.ok) {
+      console.error(
+        `API request failed: ${response.status} ${response.statusText}`
+      );
+      return null;
+    }
+
+    const result: Movie[] = await response.json();
+    return result;
+  } catch (error) {
+    console.error("API fetch error:", error);
+    return null;
+  }
+}
+
+export function getTrendingMovies(): Promise<Movie[] | null> {
+  return fetchMovies("/api/movies/trending");
+}
+
+export function getNowPlayingMovies(region: string): Promise<Movie[] | null> {
+  return fetchMovies(
+    `/api/movies/now-playing?region=${encodeURIComponent(region)}`
+  );
+}
+
+export function getUpcomingMovies(region: string): Promise<Movie[] | null> {
+  return fetchMovies(
+    `/api/movies/upcoming?region=${encodeURIComponent(region)}`
+  );
+}
+
+export function getSearchResults(term: string): Promise<Movie[] | null> {
+  return fetchMovies(`/api/search?term=${encodeURIComponent(term)}`);
+}

--- a/client/src/data/loaders.ts
+++ b/client/src/data/loaders.ts
@@ -1,7 +1,13 @@
+import "server-only";
+
 import { cache } from "react";
 
 import type { CastAndCrew, Movie, Person, PersonMovieCredit } from "@/types";
-import { fetchAPI, fetchAPIList } from "@/utils/fetch-apis";
+import {
+  fetchAPI,
+  fetchAPIList,
+  tmdbRequestOptions,
+} from "@/utils/fetch-apis";
 
 const BASE_URL = process.env.NEXT_PUBLIC_API_URL;
 
@@ -117,7 +123,7 @@ export const getSearchResults = cache(
       console.error("NEXT_PUBLIC_API_URL is not defined");
       return null;
     }
-    const url = `${BASE_URL}/search/movie?query=${term}&include_adult=false&language=en-US&page=1`;
+    const url = `${BASE_URL}/search/movie?query=${encodeURIComponent(term)}&include_adult=false&language=en-US&page=1`;
     const searchResults = await fetchAPIList<Movie>(url);
 
     if (!searchResults) {
@@ -151,12 +157,7 @@ export const getMovieTrailer = cache(
     try {
       const url = `${BASE_URL}/movie/${movieId}/videos?language=en-US`;
 
-      const response = await fetch(url, {
-        headers: {
-          Authorization: process.env.NEXT_PUBLIC_API_KEY || "",
-          accept: "application/json",
-        },
-      });
+      const response = await fetch(url, tmdbRequestOptions());
 
       if (!response.ok) {
         return null;

--- a/client/src/lib/api.ts
+++ b/client/src/lib/api.ts
@@ -1,0 +1,34 @@
+import { NextResponse } from "next/server";
+
+import type { Movie } from "@/types";
+
+// TMDB data changes slowly, so cache at the CDN. Without this, routing client
+// requests through our own routes would mean one TMDB call per visitor.
+const CACHE_CONTROL = "public, s-maxage=300, stale-while-revalidate=600";
+
+/**
+ * Wraps a loader result in a JSON response, turning a failed upstream call
+ * into a 502 so the client can distinguish "no results" from "TMDB is down".
+ */
+export function movieListResponse(
+  movies: Movie[] | null,
+  errorMessage: string
+) {
+  if (!movies) {
+    return NextResponse.json({ error: errorMessage }, { status: 502 });
+  }
+
+  return NextResponse.json(movies, {
+    headers: { "Cache-Control": CACHE_CONTROL },
+  });
+}
+
+/**
+ * Reads the `region` query param, falling back to US for anything that isn't
+ * an ISO 3166-1 alpha-2 code so untrusted input never reaches the TMDB URL.
+ */
+export function regionFromRequest(request: Request): string {
+  const region = new URL(request.url).searchParams.get("region");
+
+  return region && /^[a-z]{2}$/i.test(region) ? region.toUpperCase() : "US";
+}

--- a/client/src/utils/fetch-apis.ts
+++ b/client/src/utils/fetch-apis.ts
@@ -1,4 +1,24 @@
+import "server-only";
+
 import type { Movie } from "@/types";
+
+/**
+ * Request options shared by every TMDB call.
+ *
+ * TMDB_API_KEY is deliberately not prefixed with NEXT_PUBLIC_ — the read
+ * access token must stay on the server. Client components reach TMDB through
+ * the route handlers in src/app/api instead. The `server-only` import above
+ * turns an accidental client import of this module into a build error.
+ */
+export function tmdbRequestOptions(): RequestInit {
+  return {
+    headers: {
+      Authorization: `Bearer ${process.env.TMDB_API_KEY || ""}`,
+      accept: "application/json",
+    },
+    method: "GET",
+  };
+}
 
 /**
  * Generic API fetch utility for single resource endpoints
@@ -6,13 +26,7 @@ import type { Movie } from "@/types";
  * @returns Promise resolving to the fetched data or null on error
  */
 export async function fetchAPI<T = Movie>(url: string): Promise<T | null> {
-  const options: RequestInit = {
-    headers: {
-      Authorization: process.env.NEXT_PUBLIC_API_KEY || "",
-      accept: "application/json",
-    },
-    method: "GET",
-  };
+  const options = tmdbRequestOptions();
 
   try {
     const response = await fetch(url, options);
@@ -40,13 +54,7 @@ export async function fetchAPI<T = Movie>(url: string): Promise<T | null> {
 export async function fetchAPIList<T = Movie>(
   url: string
 ): Promise<T[] | null> {
-  const options: RequestInit = {
-    headers: {
-      Authorization: process.env.NEXT_PUBLIC_API_KEY || "",
-      accept: "application/json",
-    },
-    method: "GET",
-  };
+  const options = tmdbRequestOptions();
 
   try {
     const response = await fetch(url, options);


### PR DESCRIPTION
NEXT_PUBLIC_API_KEY was read by client components, so Next.js inlined the token into the browser bundle — it shipped in .next/static on every deploy. Netlify's secrets scanning correctly flagged it and blocked the build.

Rename it to TMDB_API_KEY (no NEXT_PUBLIC_ prefix) and mark loaders.ts and fetch-apis.ts as server-only, so an accidental client import is a build error rather than a silent leak. Client components now reach TMDB through route handlers under src/app/api via a matching client-loaders.ts, which keeps the existing call signatures and parallel fetching intact.

The Bearer prefix now comes from code, so TMDB_API_KEY holds the bare token. Responses are cached at the CDN so the extra hop doesn't turn into one TMDB call per visitor, and the region param is validated before reaching the URL.

netlify.toml omits the docs files from secrets scanning, since the env var examples in them are placeholders rather than real values.