### PR TITLE
Set the Netlify publish directory to .next

### DIFF
--- a/client/.gitignore
+++ b/client/.gitignore
@@ -36,6 +36,9 @@ yarn-error.log*
 # vercel
 .vercel
 
+# netlify (deno.lock is emitted by edge function bundling)
+deno.lock
+
 # typescript
 *.tsbuildinfo
 next-env.d.ts

--- a/client/netlify.toml
+++ b/client/netlify.toml
@@ -1,3 +1,10 @@
+[build]
+  command = "npm run build"
+  # Next.js Runtime v5 reads the build output from .next and turns SSR routes,
+  # API routes and proxy.ts into Netlify Functions/Edge Functions. Without this,
+  # Netlify falls back to publishing the base directory (the raw source).
+  publish = ".next"
+
 [build.environment]
   # Documentation files contain placeholder env var examples, not real secrets.
   SECRETS_SCAN_OMIT_PATHS = "README.md,AGENTS.md,.env.example"


### PR DESCRIPTION
The site had no publish directory configured, so Netlify fell back to publishing the base directory (client/) and uploaded the raw source tree instead of a build. The root returned 404 because no index.html existed, and the deploy shipped zero functions -- the Next.js Runtime never produced a server handler, so SSR, the API routes and proxy.ts had nowhere to run.

Declaring publish in netlify.toml keeps the setting in version control and takes precedence over the dashboard. Verified with a local `netlify build`: the runtime now engages and emits ___netlify-server-handler and ___netlify-edge-handler-node-middleware.

Also ignore deno.lock, which the edge function bundler writes into the working tree during a build.