### PR TITLE
Declare the Next.js Runtime explicitly in netlify.toml

### DIFF
--- a/client/netlify.toml
+++ b/client/netlify.toml
@@ -5,6 +5,13 @@
   # Netlify falls back to publishing the base directory (the raw source).
   publish = ".next"
 
+# Netlify only auto-installs the Next.js Runtime when CI framework detection
+# finds Next.js, which it misses here because the repo root has no package.json
+# (the app lives in the base directory, client/). Without the runtime the raw
+# .next directory is published as static files and no server handler exists.
+[[plugins]]
+  package = "@netlify/plugin-nextjs"
+
 [build.environment]
   # Documentation files contain placeholder env var examples, not real secrets.
   SECRETS_SCAN_OMIT_PATHS = "README.md,AGENTS.md,.env.example"


### PR DESCRIPTION
Setting the publish directory got .next uploaded, but the deploy still shipped no functions and no redirect rules -- Netlify published the raw .next directory as static files, so the root kept returning 404. The Next.js Runtime was never running in CI: the site's plugin list is empty and nothing transformed the build output.

Netlify only auto-installs the runtime when CI framework detection finds Next.js. Detection misses it here because the repo root has no package.json; the app lives in the base directory, client/. The local CLI detects it fine since it runs from inside client/, which is why `netlify build` produced a server handler while CI did not.

Declaring the plugin removes the dependence on detection entirely.