### PR TITLE
Vary the API cache key on term and region

### DIFF
--- a/client/src/app/api/movies/now-playing/route.ts
+++ b/client/src/app/api/movies/now-playing/route.ts
@@ -4,5 +4,7 @@ import { movieListResponse, regionFromRequest } from "@/lib/api";
 export async function GET(request: Request) {
   const movies = await getNowPlayingMovies(regionFromRequest(request));
 
-  return movieListResponse(movies, "Failed to fetch now playing movies");
+  return movieListResponse(movies, "Failed to fetch now playing movies", [
+    "region",
+  ]);
 }

--- a/client/src/app/api/movies/upcoming/route.ts
+++ b/client/src/app/api/movies/upcoming/route.ts
@@ -4,5 +4,7 @@ import { movieListResponse, regionFromRequest } from "@/lib/api";
 export async function GET(request: Request) {
   const movies = await getUpcomingMovies(regionFromRequest(request));
 
-  return movieListResponse(movies, "Failed to fetch upcoming movies");
+  return movieListResponse(movies, "Failed to fetch upcoming movies", [
+    "region",
+  ]);
 }

--- a/client/src/app/api/search/route.ts
+++ b/client/src/app/api/search/route.ts
@@ -5,10 +5,10 @@ export async function GET(request: Request) {
   const term = new URL(request.url).searchParams.get("term");
 
   if (!term) {
-    return movieListResponse([], "Failed to fetch search results");
+    return movieListResponse([], "Failed to fetch search results", ["term"]);
   }
 
   const movies = await getSearchResults(term);
 
-  return movieListResponse(movies, "Failed to fetch search results");
+  return movieListResponse(movies, "Failed to fetch search results", ["term"]);
 }

--- a/client/src/lib/api.ts
+++ b/client/src/lib/api.ts
@@ -9,18 +9,28 @@ const CACHE_CONTROL = "public, s-maxage=300, stale-while-revalidate=600";
 /**
  * Wraps a loader result in a JSON response, turning a failed upstream call
  * into a 502 so the client can distinguish "no results" from "TMDB is down".
+ *
+ * `varyByQuery` names the query params that change the response. Netlify's CDN
+ * narrows the cache key to Next.js's own internal params, so anything else --
+ * `term`, `region` -- is ignored unless declared here, and every caller would
+ * share one cache entry for the whole s-maxage window.
  */
 export function movieListResponse(
   movies: Movie[] | null,
-  errorMessage: string
+  errorMessage: string,
+  varyByQuery?: string[]
 ) {
   if (!movies) {
     return NextResponse.json({ error: errorMessage }, { status: 502 });
   }
 
-  return NextResponse.json(movies, {
-    headers: { "Cache-Control": CACHE_CONTROL },
-  });
+  const headers: Record<string, string> = { "Cache-Control": CACHE_CONTROL };
+
+  if (varyByQuery?.length) {
+    headers["Netlify-Vary"] = `query=${varyByQuery.join("|")}`;
+  }
+
+  return NextResponse.json(movies, { headers });
 }
 
 /**


### PR DESCRIPTION
Netlify's CDN narrows the cache key for these route handlers to Next.js's own internal query params (__nextDataReq, _rsc), so `term` and `region` were ignored entirely. Combined with the s-maxage=300 the handlers already set, that meant one cache entry shared across every caller: for five minutes each search returned whatever the first search matched, and now-playing/upcoming served whichever region was requested first.

Observed directly -- a request to /api/search?query=dune (which short-circuits to []) poisoned later /api/search?term=dune requests, which returned the cached [] rather than results.

Declaring Netlify-Vary puts the params that change the response back into the cache key. Trending takes no params, so it stays unvaried. The empty short-circuit in the search route declares it too, since that response was the one doing the poisoning.

Verified against a production build: search returns
`netlify-vary: query=term`, now-playing `query=region`, trending none.