### PR TITLE
Dismiss the theme tooltip before accessibility scans

### DIFF
--- a/client/tests/cast-and-crew-metadata-accessibility.spec.ts
+++ b/client/tests/cast-and-crew-metadata-accessibility.spec.ts
@@ -2,6 +2,8 @@
 import AxeBuilder from "@axe-core/playwright";
 import { expect, test } from "@playwright/test";
 
+import { switchToDarkMode } from "./helpers/theme";
+
 // Tom Hanks — stable, well-known TMDB entry (ID 31)
 const KNOWN_PERSON_ID = "31";
 const KNOWN_PERSON_NAME = "Tom Hanks";
@@ -21,11 +23,8 @@ test.describe("Cast and crew person page does not have accessibility issues", ()
     expect(accessibilityScanResults.violations).toEqual([]);
 
     // Test dark mode
-    const themeToggle = page.locator("#themeToggle");
-    await themeToggle.first().click();
     console.log("Switching to Dark mode for accessibility testing");
-    const darkModeClass = await page.locator("html").getAttribute("class");
-    expect(darkModeClass).toContain("dark");
+    await switchToDarkMode(page);
 
     const darkModeAccessibilityScanResults = await new AxeBuilder({
       page,

--- a/client/tests/helpers/theme.ts
+++ b/client/tests/helpers/theme.ts
@@ -1,0 +1,23 @@
+import { expect, type Page } from "@playwright/test";
+
+/**
+ * Switches the page to dark mode and waits for it to settle.
+ *
+ * Playwright's click leaves the pointer resting on the trigger, so Radix keeps
+ * the tooltip open. Its content portals to <body>, outside any landmark, and
+ * axe's `region` rule flags it. That made the accessibility scans intermittent:
+ * they failed only when the scan started before the tooltip finished animating
+ * in. Moving the pointer away and waiting for the tooltip to unmount lets the
+ * scans see the page at rest.
+ */
+export async function switchToDarkMode(page: Page) {
+  const themeToggle = page.locator("#themeToggle").first();
+
+  await themeToggle.click();
+
+  await page.mouse.move(0, 0);
+  await themeToggle.blur();
+  await expect(page.getByRole("tooltip")).toHaveCount(0);
+
+  await expect(page.locator("html")).toHaveClass(/dark/);
+}

--- a/client/tests/home-page-metadata-accessibility.spec.ts
+++ b/client/tests/home-page-metadata-accessibility.spec.ts
@@ -2,6 +2,8 @@
 import AxeBuilder from "@axe-core/playwright";
 import { expect, test } from "@playwright/test";
 
+import { switchToDarkMode } from "./helpers/theme";
+
 test.describe("Homepage does not have accessibility issues", () => {
   test("Should not have any automatically detectable accessibility issues", async ({
     page,
@@ -17,11 +19,8 @@ test.describe("Homepage does not have accessibility issues", () => {
     expect(accessibilityScanResults.violations).toEqual([]);
 
     // Test dark mode
-    const themeToggle = page.locator("#themeToggle");
-    await themeToggle.first().click();
     console.log("Switching to Dark mode for accessibility testing");
-    const darkModeClass = await page.locator("html").getAttribute("class");
-    expect(darkModeClass).toContain("dark");
+    await switchToDarkMode(page);
 
     const darkModeAccessibilityScanResults = await new AxeBuilder({
       page,

--- a/client/tests/movie-detail-metadata-accessibility.spec.ts
+++ b/client/tests/movie-detail-metadata-accessibility.spec.ts
@@ -2,6 +2,8 @@
 import AxeBuilder from "@axe-core/playwright";
 import { expect, test } from "@playwright/test";
 
+import { switchToDarkMode } from "./helpers/theme";
+
 // The Dark Knight — stable, well-known TMDB entry (ID 155)
 const KNOWN_MOVIE_ID = "155";
 const KNOWN_MOVIE_TITLE = "The Dark Knight";
@@ -22,11 +24,8 @@ test.describe("Movie detail page does not have accessibility issues", () => {
     expect(accessibilityScanResults.violations).toEqual([]);
 
     // Test dark mode
-    const themeToggle = page.locator("#themeToggle");
-    await themeToggle.first().click();
     console.log("Switching to Dark mode for accessibility testing");
-    const darkModeClass = await page.locator("html").getAttribute("class");
-    expect(darkModeClass).toContain("dark");
+    await switchToDarkMode(page);
 
     const darkModeAccessibilityScanResults = await new AxeBuilder({
       page,

--- a/client/tests/search-metadata-accessibility.spec.ts
+++ b/client/tests/search-metadata-accessibility.spec.ts
@@ -2,6 +2,8 @@
 import AxeBuilder from "@axe-core/playwright";
 import { expect, test } from "@playwright/test";
 
+import { switchToDarkMode } from "./helpers/theme";
+
 const KNOWN_MOVIE_TITLE = "Inception";
 
 test.describe("Search results page does not have accessibility issues", () => {
@@ -26,11 +28,8 @@ test.describe("Search results page does not have accessibility issues", () => {
     expect(accessibilityScanResults.violations).toEqual([]);
 
     // Test dark mode
-    const themeToggle = page.locator("#themeToggle");
-    await themeToggle.first().click();
     console.log("Switching to Dark mode for accessibility testing");
-    const darkModeClass = await page.locator("html").getAttribute("class");
-    expect(darkModeClass).toContain("dark");
+    await switchToDarkMode(page);
 
     const darkModeAccessibilityScanResults = await new AxeBuilder({
       page,


### PR DESCRIPTION
The axe `region` violation in CI came from the theme toggle's tooltip, not from page content. Playwright's click leaves the pointer resting on the trigger, so Radix keeps the tooltip open and portals its content to <body>, outside any landmark. Both flagged nodes were the tooltip: the visible <p> and Radix's hidden role="tooltip" duplicate.

It failed intermittently because it is a race -- the scan only sees the violation when it starts before the open animation finishes. Locally on webkit it reproduced once in six runs.

Move the pointer away and wait for the tooltip to unmount so the scans see the page at rest. All four accessibility specs had the same block copied verbatim, so this lives in a shared helper rather than being duplicated four times.

Verified on webkit: 10/10 passes after the change, against a reproducible failure before it.