### PR TITLE
Set the publish directory for the monorepo layout

### DIFF
--- a/apps/web/netlify.toml
+++ b/apps/web/netlify.toml
@@ -7,11 +7,15 @@
 # Pointing the base directory here instead would install inside the app, and
 # that dependency would fail to resolve.
 #
-# No `publish` key: Next.js on Netlify is handled by the Next Runtime, which
-# resolves the output itself.
+# `publish` must point at the Next.js build output. Left unset it defaults to
+# the package directory itself, and the Next Runtime rejects that: "Your publish
+# directory cannot be the same as the base directory of your site."
 
 [build]
   command = "pnpm turbo build --filter=@moviewatchlist/web"
+  # Relative to the base directory (the repo root), not to this file --
+  # ".next" alone resolves to /.next and fails.
+  publish = "apps/web/.next"
 
 # Declared rather than relying on Netlify's automatic install. On `main` the
 # runtime silently never ran -- CI framework detection missed Next.js, and the


### PR DESCRIPTION
With the base directory at the repo root and the package directory at apps/web, Netlify defaults `publish` to the package directory itself. The Next.js Runtime rejects that outright:

  Your publish directory cannot be the same as the base directory of
  your site.

The build succeeded every time; only the plugin's onBuild failed, so the deploy never produced a server handler.

The path is deliberately `apps/web/.next` rather than `.next`. Paths in netlify.toml resolve against the base directory, not against the file's own location -- confirmed by resolving the config locally, where `.next` came out as <repo-root>/.next while `apps/web/.next` resolves to the app's actual build output.

This also corrects the comment claiming the runtime resolves the output on its own. It does not; `main` needed the same key before the monorepo merge.