### PR TITLE
Document why wrangler.jsonc declares no vars

### DIFF
--- a/apps/web/wrangler.jsonc
+++ b/apps/web/wrangler.jsonc
@@ -28,6 +28,21 @@
     "run_worker_first": false,
   },
 
+  // No "vars" block, deliberately.
+  //
+  // Every `wrangler deploy` / `versions upload` treats this file as the source
+  // of truth for vars and deletes any plaintext variable set in the dashboard
+  // that is not listed here. Secrets are stored separately and survive, which
+  // is why TMDB_API_KEY persisted through a deploy while everything else
+  // vanished. Pass `--keep-vars` if dashboard-set vars ever need to stick.
+  //
+  // Nothing belongs here today: TMDB_API_KEY is the only value read at runtime
+  // and it is a secret. The six NEXT_PUBLIC_* variables are inlined into the
+  // bundle by `next build`, so they must be set as *build* environment
+  // variables in the Cloudflare build configuration. Adding them here would
+  // not help — by the time the Worker runs, the bundle has already baked in
+  // whatever was present at build time.
+
   // Required for ISR: the Worker calls itself to revalidate a stale page.
   "services": [
     {


### PR DESCRIPTION
A deploy silently removed every dashboard environment variable except TMDB_API_KEY. Wrangler treats this file as the source of truth for vars and deletes plaintext ones it does not find here; secrets are stored separately, so the one secret survived and looked like the exception.

Nothing should be added to fix that. The only value read at runtime is TMDB_API_KEY, already a secret. The rest are NEXT_PUBLIC_*, which `next build` inlines into the bundle -- they have to be set as build environment variables, and declaring them as Worker vars would look like a fix while changing nothing.