### PR TITLE
Persist ISR pages to R2 instead of re-rendering every request

### DIFF
--- a/apps/web/open-next.config.ts
+++ b/apps/web/open-next.config.ts
@@ -1,24 +1,37 @@
 import { defineCloudflareConfig } from "@opennextjs/cloudflare";
+import r2IncrementalCache from "@opennextjs/cloudflare/overrides/incremental-cache/r2-incremental-cache";
+import { withRegionalCache } from "@opennextjs/cloudflare/overrides/incremental-cache/regional-cache";
 
 /**
  * Cloudflare adapter config.
  *
- * No `incrementalCache` is set yet, which means ISR pages are re-rendered per
- * request rather than persisted — the Worker still runs for every hit on
- * /movies/[id], /tv/[id] and /cast-and-crew/[id]. The prerendered routes (/,
- * robots.txt, sitemap.xml) are served straight from static assets and cost
- * nothing either way.
+ * ISR pages persist to R2. Without an incremental cache they were re-rendered
+ * in the Worker on every request, which made `export const revalidate` on the
+ * detail pages decorative — the pages were correct but nothing was reused.
  *
- * To get the caching those routes were written for, create an R2 bucket,
- * uncomment the `r2_buckets` binding in wrangler.jsonc, and swap the export
- * below for:
+ * R2 rather than KV: KV is eventually consistent and the adapter's docs advise
+ * against it for caching. The static-assets cache is read-only, so it cannot
+ * hold pages rendered on demand, and `generateStaticParams` returns [] — none
+ * of the detail pages are prerendered at build time.
  *
- *   import r2IncrementalCache from "@opennextjs/cloudflare/overrides/incremental-cache/r2-incremental-cache";
- *   export default defineCloudflareConfig({ incrementalCache: r2IncrementalCache });
+ * The regional cache sits in front of R2 so a hit is served from the colo
+ * rather than a bucket round trip. `long-lived` is the documented mode for an
+ * app that revalidates: ISR responses are reused for up to 30 minutes and
+ * refreshed in the background.
  *
- * R2 is the recommended store here. KV is eventually consistent and the docs
- * advise against it for caching; the static-assets cache is read-only, so it
- * cannot hold pages rendered on demand — and since generateStaticParams
- * returns [], none of the detail pages are prerendered at build time.
+ * Deliberately not configured: `tagCache`, `queue`, and `cachePurge`. Those
+ * matter for on-demand revalidation, and the only `revalidatePath` calls here
+ * target /profile and /watchlist, which are dynamic and never cached. The
+ * detail pages revalidate on a timer, which the default queue handles through
+ * the WORKER_SELF_REFERENCE binding in wrangler.jsonc.
+ *
+ * `enableCacheInterception` is also off. It would let cached responses return
+ * before the full routing stack runs, cutting Worker time further, but it
+ * interacts with middleware and this migration has produced enough surprises —
+ * worth trying separately, once the cache is proven.
  */
-export default defineCloudflareConfig();
+export default defineCloudflareConfig({
+  incrementalCache: withRegionalCache(r2IncrementalCache, {
+    mode: "long-lived",
+  }),
+});

--- a/apps/web/wrangler.jsonc
+++ b/apps/web/wrangler.jsonc
@@ -51,15 +51,15 @@
     },
   ],
 
-  // Uncomment once an R2 bucket exists to give ISR somewhere to persist
-  // rendered pages. Without it every detail-page request re-renders in the
-  // Worker — see the note in open-next.config.ts.
-  // "r2_buckets": [
-  //   {
-  //     "binding": "NEXT_INC_CACHE_R2_BUCKET",
-  //     "bucket_name": "moviewatchlist-cache",
-  //   },
-  // ],
+  // Where ISR persists rendered pages. The binding name is fixed — the adapter
+  // looks for NEXT_INC_CACHE_R2_BUCKET specifically, so renaming it silently
+  // disables the cache rather than failing. See open-next.config.ts.
+  "r2_buckets": [
+    {
+      "binding": "NEXT_INC_CACHE_R2_BUCKET",
+      "bucket_name": "moviewatchlist-cache",
+    },
+  ],
 
   "observability": {
     "enabled": false,


### PR DESCRIPTION
The detail routes carried `export const revalidate` and a `generateStaticParams` returning [], but no incremental cache was configured -- so nothing was ever stored and each request to /movies/[id], /tv/[id] and /cast-and-crew/[id] re-rendered in the Worker. The pages were correct; the caching was decorative.

R2 rather than KV: KV is eventually consistent and the adapter's own docs advise against it for caching, while the static-assets cache is read-only and so cannot hold pages rendered on demand. A regional cache sits in front in `long-lived` mode, the documented choice for an app that revalidates -- responses are reused for up to 30 minutes and refreshed in the background rather than costing a bucket round trip per hit.

Left unconfigured on purpose: tagCache, queue and cachePurge serve on-demand revalidation, and the only revalidatePath calls here target /profile and /watchlist, which are dynamic and never cached. Timer-based revalidation uses the default queue via WORKER_SELF_REFERENCE. enableCacheInterception is off for now -- it would cut Worker time further but interacts with middleware, so it is worth proving separately.

Verified against a local Worker with simulated R2: the first request to /movies/550 misses and takes 525ms, subsequent requests hit and take 6ms.