### PR TITLE
Build the Cloudflare Worker in CI

### DIFF
--- a/.github/workflows/worker-build.yml
+++ b/.github/workflows/worker-build.yml
@@ -1,0 +1,55 @@
+name: Worker Build
+
+# Preview builds are disabled in Cloudflare, so nothing validated the Worker
+# bundle before merge. The other jobs run `next build` and `eslint`, neither of
+# which touches the adapter — and the adapter is where this has actually broken:
+# Next 16 pins proxy.ts to the Node runtime, OpenNext supports only edge
+# middleware, and `next build` passes straight through that. The failure only
+# appeared on deploy, after merge.
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+jobs:
+  worker-build:
+    name: Build the Cloudflare Worker
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      # No `version:` — pnpm/action-setup errors out if it is given one while
+      # the root package.json also sets `packageManager`.
+      - uses: pnpm/action-setup@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version-file: .node-version
+          cache: "pnpm"
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      # Mirrors the env the real Cloudflare build runs with. NEXT_PUBLIC_* are
+      # inlined at build time, so a bundle built without them is not the bundle
+      # that ships — worth keeping faithful even though nothing here asserts on
+      # the values.
+      - name: Build Worker
+        env:
+          TMDB_API_KEY: ${{ secrets.TMDB_API_KEY }}
+          NEXT_PUBLIC_API_URL: https://api.themoviedb.org/3
+          NEXT_PUBLIC_API_IMAGE_PATH: https://image.tmdb.org/t/p/
+          NEXT_PUBLIC_SITE_URL: ${{ vars.NEXT_PUBLIC_SITE_URL }}
+          NEXT_PUBLIC_SITE_NAME: ${{ vars.NEXT_PUBLIC_SITE_NAME }}
+          NEXT_PUBLIC_SUPABASE_URL: ${{ secrets.NEXT_PUBLIC_SUPABASE_URL }}
+          NEXT_PUBLIC_SUPABASE_ANON_KEY: ${{ secrets.NEXT_PUBLIC_SUPABASE_ANON_KEY }}
+          NEXT_TELEMETRY_DISABLED: "1"
+        run: pnpm run cf:build
+
+      # `cf:build` succeeding is not quite proof: the adapter can finish and
+      # still leave nothing to deploy, which is how the first Cloudflare deploy
+      # failed ("Missing entry-point to Worker script").
+      - name: Verify the Worker entry point exists
+        run: test -f apps/web/.open-next/worker.js


### PR DESCRIPTION
Disabling preview builds removed the last thing that compiled the Worker before merge. The existing jobs run `next build` and `eslint`, and neither exercises the adapter -- which is precisely where this has broken: Next 16 pins proxy.ts to the Node runtime, OpenNext supports only edge middleware, and `next build` passes straight through the conflict. That failure reached main and only surfaced on deploy.

The job mirrors the env the real Cloudflare build runs with, since NEXT_PUBLIC_* are inlined at build time and a bundle built without them is not the bundle that ships.

It also asserts .open-next/worker.js exists rather than trusting the exit code. The very first Cloudflare deploy failed with "Missing entry-point to Worker script" after a build that had reported success, so the two are worth checking separately.

Kept out of the Playwright workflow deliberately: `cf:build` runs `next build` and then post-processes the output, and the test server should not be serving a bundle that has been through that.