### PR TITLE
Update the header when a server action changes the session

### DIFF
--- a/apps/web/src/components/header/user-menu.tsx
+++ b/apps/web/src/components/header/user-menu.tsx
@@ -1,8 +1,9 @@
 "use client";
 
-import { useEffect, useState, useTransition } from "react";
+import { useEffect, useMemo, useState, useTransition } from "react";
 
 import Link from "next/link";
+import { usePathname } from "next/navigation";
 
 import { BookMarked, LogIn, LogOut, User } from "lucide-react";
 
@@ -24,28 +25,46 @@ function UserMenu() {
   // so the first paint renders neutral space rather than flashing "Sign in" at
   // a user who is in fact signed in.
   const [email, setEmail] = useState<string | null | undefined>(undefined);
+  // Sign-in and sign-out are both server actions: they change the cookie and
+  // redirect, so supabase-js in this tab never performs either and
+  // onAuthStateChange stays silent. This component lives in the root layout, so
+  // it survives the redirect without remounting, and kept offering "Sign in" to
+  // someone already signed in. Detail pages looked correct only because their
+  // buttons mount fresh. Re-reading on navigation covers both directions, since
+  // each redirect is itself a navigation.
+  const pathname = usePathname();
+  // One client for the component's life. Building a new one per navigation
+  // spawns multiple GoTrue instances against the same storage.
+  const supabase = useMemo(() => createClient(), []);
 
   useEffect(() => {
-    const supabase = createClient();
     let active = true;
 
-    supabase.auth.getUser().then(({ data }) => {
-      if (active) setEmail(data.user?.email ?? null);
-    });
-
-    // Keeps the header honest after sign-in/sign-out without a reload, which
-    // the server-rendered email prop used to depend on.
-    const {
-      data: { subscription },
-    } = supabase.auth.onAuthStateChange((_event, session) => {
-      if (active) setEmail(session?.user?.email ?? null);
+    // getSession, not getUser: this only decides what the header renders, and
+    // getUser is a round trip to the auth server on every navigation. That cost
+    // was enough to push detail pages past their load budget in Firefox. Route
+    // gating still uses requireUser() on the server, and RLS guards the data —
+    // nothing is authorized on the strength of this read.
+    supabase.auth.getSession().then(({ data }) => {
+      if (active) setEmail(data.session?.user?.email ?? null);
     });
 
     return () => {
       active = false;
-      subscription.unsubscribe();
     };
-  }, []);
+  }, [pathname, supabase]);
+
+  useEffect(() => {
+    // Catches whatever happens without a navigation: token refreshes, and
+    // sign-outs performed in another tab.
+    const {
+      data: { subscription },
+    } = supabase.auth.onAuthStateChange((_event, session) => {
+      setEmail(session?.user?.email ?? null);
+    });
+
+    return () => subscription.unsubscribe();
+  }, [supabase]);
 
   if (email === undefined) {
     return <div aria-hidden className="h-9 w-9" />;

--- a/apps/web/tests/sign-in.spec.ts
+++ b/apps/web/tests/sign-in.spec.ts
@@ -1,0 +1,52 @@
+import { expect, test } from "@playwright/test";
+
+// The browser projects reuse the session written by auth.setup.ts, which means
+// none of them ever exercise signing in. Start from a clean context so this
+// spec drives the real flow.
+test.use({ storageState: { cookies: [], origins: [] } });
+
+test.describe("Sign in", () => {
+  test("Header shows the account menu without a further navigation", async ({
+    page,
+  }, testInfo) => {
+    // One project only. This drives a real sign-in against the same account the
+    // other specs share, and running it per browser destabilised them — a full
+    // suite went from 84 passing to one watchlist failure per run, in a
+    // different test each time. The behaviour under test is client-side state,
+    // not anything browser-specific, so a second and third sign-in buys
+    // coverage that is not worth what it costs the rest of the run.
+    test.skip(
+      testInfo.project.name !== "chromium",
+      "drives a real sign-in against the shared account"
+    );
+
+    const email = process.env.E2E_EMAIL;
+    const password = process.env.E2E_PASSWORD;
+
+    expect(
+      email,
+      "E2E_EMAIL is not set — add it to apps/web/.env (or repository secrets in CI)"
+    ).toBeTruthy();
+    expect(
+      password,
+      "E2E_PASSWORD is not set — add it to apps/web/.env (or repository secrets in CI)"
+    ).toBeTruthy();
+
+    await page.goto("/login");
+    await page.getByLabel("Email").fill(email!);
+    await page.getByLabel("Password").fill(password!);
+    await page.getByRole("button", { name: "Sign in" }).click();
+
+    // A failed sign-in re-renders /login with an error rather than redirecting.
+    await page.waitForURL((url) => !url.pathname.startsWith("/login"));
+
+    // The regression: signing in is a server action, so supabase-js in this tab
+    // never sees it, and the header — which lives in the root layout and
+    // survives the redirect without remounting — kept offering "Sign in" to
+    // someone already signed in. Detail pages looked right only because their
+    // buttons mount fresh. Asserting here, with no navigation in between, is
+    // the whole point of the test.
+    await expect(page.getByRole("button", { name: "User menu" })).toBeVisible();
+    await expect(page.getByRole("link", { name: "Sign in" })).toHaveCount(0);
+  });
+});


### PR DESCRIPTION
Signing in left the header offering "Sign in" until the next navigation, while a detail page would correctly report the title was on your watchlist. Both readings came from the same session; only the header was stale.

Sign-in and sign-out are server actions. They change the cookie and redirect, so supabase-js in the tab never performs either and onAuthStateChange never fires. The header lives in the root layout and survives that redirect without remounting, so its one-shot effect never ran again. The detail pages looked right only because their buttons mount fresh on navigation -- the same bug was there, hidden by remounting.

Re-reading on pathname change covers both directions, since each redirect is a navigation. It reads getSession rather than getUser: this decides what the header renders, and getUser is a round trip to the auth server on every navigation. That cost was not theoretical -- it pushed Firefox detail pages past their load budget and broke the watchlist specs, which pass again on the cheaper read. Route gating still uses requireUser() on the server and RLS still guards the data; nothing is authorised on this. The client is also built once now instead of per navigation, which was spawning a GoTrue instance each time against the same storage.

The spec reproduces the original bug: it fails against the previous component and passes against this one. It is chromium-only, because driving a real sign-in per browser against the shared account cost the suite a watchlist failure per run, in a different test each time.