### PR TITLE
Sign out in the browser instead of through a server action

### DIFF
--- a/apps/web/src/app/auth/actions.ts
+++ b/apps/web/src/app/auth/actions.ts
@@ -1,6 +1,5 @@
 "use server";
 
-import { revalidatePath } from "next/cache";
 import { redirect } from "next/navigation";
 
 import { createClient } from "@/lib/supabase/server";
@@ -20,7 +19,12 @@ export async function login(formData: FormData) {
     );
   }
 
-  revalidatePath("/", "layout");
+  // No `revalidatePath("/", "layout")` here. It existed so the header would
+  // pick up the new session back when the layout read it and passed down an
+  // email; the header resolves its own state now. It also reached further than
+  // it looked — "layout" covers every route beneath the root layout, so each
+  // sign-in asked to invalidate the whole ISR cache. That is inert while no tag
+  // cache is configured on Cloudflare, which is what would make it easy to miss.
   redirect(next.startsWith("/") ? next : "/");
 }
 
@@ -45,9 +49,8 @@ export async function signup(formData: FormData) {
   redirect("/signup?message=Check your email to confirm your account.");
 }
 
-export async function signout() {
-  const supabase = await createClient();
-  await supabase.auth.signOut();
-  revalidatePath("/", "layout");
-  redirect("/");
-}
+// There is no `signout` action. It lived here, and the header called it, but a
+// server-action redirect makes React re-render the root layout on the client —
+// where next-themes keeps a <script> it will not execute, warning every time.
+// UserMenu clears the session in the browser instead, which drops the same
+// cookies and lets onAuthStateChange update the header immediately.

--- a/apps/web/src/components/header/user-menu.tsx
+++ b/apps/web/src/components/header/user-menu.tsx
@@ -3,7 +3,7 @@
 import { useEffect, useMemo, useState, useTransition } from "react";
 
 import Link from "next/link";
-import { usePathname } from "next/navigation";
+import { usePathname, useRouter } from "next/navigation";
 
 import { BookMarked, LogIn, LogOut, User } from "lucide-react";
 
@@ -16,7 +16,6 @@ import {
   DropdownMenuTrigger,
 } from "@/components/ui/dropdown-menu";
 
-import { signout } from "@/app/auth/actions";
 import { createClient } from "@/lib/supabase/client";
 
 function UserMenu() {
@@ -25,14 +24,16 @@ function UserMenu() {
   // so the first paint renders neutral space rather than flashing "Sign in" at
   // a user who is in fact signed in.
   const [email, setEmail] = useState<string | null | undefined>(undefined);
-  // Sign-in and sign-out are both server actions: they change the cookie and
-  // redirect, so supabase-js in this tab never performs either and
-  // onAuthStateChange stays silent. This component lives in the root layout, so
-  // it survives the redirect without remounting, and kept offering "Sign in" to
-  // someone already signed in. Detail pages looked correct only because their
-  // buttons mount fresh. Re-reading on navigation covers both directions, since
-  // each redirect is itself a navigation.
+  // Signing in is a server action: it sets the cookie and redirects, so
+  // supabase-js in this tab never performs it and onAuthStateChange stays
+  // silent. This component lives in the root layout, so it survives the
+  // redirect without remounting, and kept offering "Sign in" to someone already
+  // signed in. Detail pages looked correct only because their buttons mount
+  // fresh. Re-reading on navigation covers it, since the redirect is itself a
+  // navigation. Sign-out is handled in the browser (see below), so that
+  // direction updates through onAuthStateChange instead.
   const pathname = usePathname();
+  const router = useRouter();
   // One client for the component's life. Building a new one per navigation
   // spawns multiple GoTrue instances against the same storage.
   const supabase = useMemo(() => createClient(), []);
@@ -109,7 +110,19 @@ function UserMenu() {
         <DropdownMenuItem
           className="text-destructive focus:text-destructive"
           disabled={pending}
-          onSelect={() => startTransition(() => signout())}
+          onSelect={() =>
+            startTransition(async () => {
+              // Signing out in the browser rather than through the server
+              // action. The action redirected, and a server-action redirect
+              // makes React re-render the root layout on the client — where
+              // next-themes keeps a <script> that React will not execute,
+              // warning on every sign-out. Clearing the session here drops the
+              // same cookies, fires onAuthStateChange so the header updates
+              // immediately, and leaves the layout alone.
+              await supabase.auth.signOut();
+              router.push("/");
+            })
+          }
         >
           <LogOut className="mr-2 h-4 w-4" />
           Sign out

--- a/apps/web/tests/sign-in.spec.ts
+++ b/apps/web/tests/sign-in.spec.ts
@@ -1,5 +1,7 @@
 import { expect, test } from "@playwright/test";
 
+import { AUTH_STATE } from "../playwright.config";
+
 // The browser projects reuse the session written by auth.setup.ts, which means
 // none of them ever exercise signing in. Start from a clean context so this
 // spec drives the real flow.
@@ -48,5 +50,75 @@ test.describe("Sign in", () => {
     // the whole point of the test.
     await expect(page.getByRole("button", { name: "User menu" })).toBeVisible();
     await expect(page.getByRole("link", { name: "Sign in" })).toHaveCount(0);
+  });
+
+  test("Signing out clears the header without re-rendering the layout", async ({
+    page,
+  }, testInfo) => {
+    test.skip(
+      testInfo.project.name !== "chromium",
+      "drives a real sign-in against the shared account"
+    );
+    // React strips this warning from production builds, and CI serves one, so
+    // the assertion below would pass there whether or not the bug was present.
+    // Skipping says that outright rather than reporting a green run as proof.
+    test.skip(
+      !!process.env.CI,
+      "the warning only exists in development builds of React"
+    );
+
+    const email = process.env.E2E_EMAIL;
+    const password = process.env.E2E_PASSWORD;
+
+    // Only React's own warnings matter here; a failed TMDB image or an
+    // extension writing to the console should not fail the run.
+    const reactWarnings: string[] = [];
+    page.on("console", (message) => {
+      if (message.type() === "error" || message.type() === "warning") {
+        reactWarnings.push(message.text());
+      }
+    });
+
+    await page.goto("/login");
+    await page.getByLabel("Email").fill(email!);
+    await page.getByLabel("Password").fill(password!);
+    await page.getByRole("button", { name: "Sign in" }).click();
+    await page.waitForURL((url) => !url.pathname.startsWith("/login"));
+
+    await page.getByRole("button", { name: "User menu" }).click();
+    await page.getByRole("menuitem", { name: "Sign out" }).click();
+
+    await expect(page.getByRole("link", { name: "Sign in" })).toBeVisible();
+    await expect(page.getByRole("button", { name: "User menu" })).toHaveCount(
+      0
+    );
+
+    // The header is client state, so on its own it only proves the browser
+    // thinks the session is gone. Sign-out now happens in the browser rather
+    // than through a server action, which makes it worth confirming the server
+    // agrees: a protected route has to bounce.
+    await page.goto("/watchlist");
+    await expect(page).toHaveURL(/\/login/);
+
+    // Sign-out used to go through a server action, and a server-action redirect
+    // makes React re-render the root layout on the client. next-themes keeps a
+    // <script> there to set the theme before paint, which React will not
+    // execute client-side and warns about — on every sign-out.
+    expect(
+      reactWarnings.filter((text) => /script tag/i.test(text)),
+      "React warned about a script tag — the layout is being re-rendered on the client"
+    ).toEqual([]);
+
+    // Sign back in and rewrite the shared state before leaving. supabase-js
+    // signs out globally by default, so the sign-out above revoked every
+    // session for this account — including the one auth.setup.ts saved and
+    // every other spec loads. Skipping this leaves the projects that run after
+    // Chromium holding dead tokens, which surfaced as watchlist failures that
+    // looked like flake and had nothing to do with the watchlist.
+    await page.getByLabel("Email").fill(email!);
+    await page.getByLabel("Password").fill(password!);
+    await page.getByRole("button", { name: "Sign in" }).click();
+    await page.waitForURL((url) => !url.pathname.startsWith("/login"));
+    await page.context().storageState({ path: AUTH_STATE });
   });
 });


### PR DESCRIPTION
Signing out logged a React warning: "Encountered a script tag while rendering React component." The sign-out action redirected, and a server-action redirect makes React re-render the root layout on the client -- where next-themes keeps a <script> to set the theme before paint. React will not execute a script it renders client-side and says so, every time.

UserMenu clears the session in the browser now. The same cookies are dropped, the server agrees the session is gone (the spec checks that a protected route bounces, since a client-side sign-out could otherwise leave the two disagreeing), onAuthStateChange updates the header immediately, and the layout is left alone. The `signout` action had no other caller and is gone.

`revalidatePath("/", "layout")` is also dropped from `login`. I first assumed it caused the warning; removing it did not, so it is here as cleanup rather than the fix. It existed to refresh the header back when the layout read the session, and it reached further than it looked -- "layout" covers every route beneath the root layout, so each sign-in asked to invalidate the whole ISR cache. Inert while no tag cache is configured on Cloudflare, which is what would make it easy to miss.

The spec skips under CI: React strips this warning from production builds, and CI serves one, so a green run there proves nothing. It fails against the previous code in development and passes against this.

It also signs back in and rewrites the shared auth state before finishing. supabase-js signs out globally by default, so the sign-out revoked every session for the account -- including the one auth.setup.ts saves and every other spec loads. Without that, projects running after Chromium held dead tokens and failed in the watchlist, which read as flake and had nothing to do with the watchlist.