### PR TITLE
End only this browser's session when signing out

### DIFF
--- a/apps/web/src/components/header/user-menu.tsx
+++ b/apps/web/src/components/header/user-menu.tsx
@@ -119,7 +119,12 @@ function UserMenu() {
               // warning on every sign-out. Clearing the session here drops the
               // same cookies, fires onAuthStateChange so the header updates
               // immediately, and leaves the layout alone.
-              await supabase.auth.signOut();
+              //
+              // `local` scope ends this browser's session only. The default is
+              // `global`, which revokes every session the account has — signing
+              // out on a laptop would sign you out on your phone, which is not
+              // what a "Sign out" in this menu implies.
+              await supabase.auth.signOut({ scope: "local" });
               router.push("/");
             })
           }

--- a/apps/web/tests/sign-in.spec.ts
+++ b/apps/web/tests/sign-in.spec.ts
@@ -1,7 +1,5 @@
 import { expect, test } from "@playwright/test";
 
-import { AUTH_STATE } from "../playwright.config";
-
 // The browser projects reuse the session written by auth.setup.ts, which means
 // none of them ever exercise signing in. Start from a clean context so this
 // spec drives the real flow.
@@ -109,16 +107,10 @@ test.describe("Sign in", () => {
       "React warned about a script tag — the layout is being re-rendered on the client"
     ).toEqual([]);
 
-    // Sign back in and rewrite the shared state before leaving. supabase-js
-    // signs out globally by default, so the sign-out above revoked every
-    // session for this account — including the one auth.setup.ts saved and
-    // every other spec loads. Skipping this leaves the projects that run after
-    // Chromium holding dead tokens, which surfaced as watchlist failures that
-    // looked like flake and had nothing to do with the watchlist.
-    await page.getByLabel("Email").fill(email!);
-    await page.getByLabel("Password").fill(password!);
-    await page.getByRole("button", { name: "Sign in" }).click();
-    await page.waitForURL((url) => !url.pathname.startsWith("/login"));
-    await page.context().storageState({ path: AUTH_STATE });
+    // Nothing to restore. Sign-out uses `local` scope, so it ends this
+    // context's session and leaves the shared one from auth.setup.ts alone.
+    // Under the default `global` scope it revoked every session on the account,
+    // and the projects running after Chromium failed on dead tokens — as
+    // watchlist failures that had nothing to do with the watchlist.
   });
 });


### PR DESCRIPTION
supabase-js signs out globally by default, revoking every session the account has. Signing out on a laptop would sign you out on your phone, which is not what a "Sign out" in this menu implies. `local` scope ends the current browser's session and leaves the rest alone.

This also removes the workaround the sign-out spec needed. It had been signing back in and rewriting the shared auth state, because a global sign-out revoked the session auth.setup.ts saves and every other spec loads -- leaving the projects that run after Chromium on dead tokens, failing in the watchlist for reasons that had nothing to do with it. Local scope means there is nothing to restore.

Full CI suite: 85 passed. A first run showed two Firefox retries; a second was clean, and the same tests have been intermittent all week independently of this change.